### PR TITLE
2 small changes to enable easy build on newer Debian/Ubuntu/Mint distros

### DIFF
--- a/chkcvc.src.dir/makefile.lnx64
+++ b/chkcvc.src.dir/makefile.lnx64
@@ -3,4 +3,4 @@ LIBS= -ldl
 CFLAGS=-O2 -D__X86_64__ 
 
 all:
-	$(CC) $(CFLAGS) $(LIBS) chkcvc64.c -o checkcvc64
+	$(CC) $(CFLAGS) chkcvc64.c -o checkcvc64 $(LIBS)

--- a/src/makefile.cvc64
+++ b/src/makefile.cvc64
@@ -46,7 +46,7 @@ CVCCOBJS=v_bbgen.o v_bbgen2.o v_bbgen3.o v_bbopt.o v_cvcms.o v_asmlnk.o \
  v_aslib.o v_regasn.o v_cvcrt.o v_xprop.o fstapi.o fastlz.o lz4.o
 
 # make normal optimized CVC that pipes .s gas files instead of making .s files
-CVCCFLGS= -D$(LINUX_VERS) $(FLG32)
+CVCCFLGS= -D$(LINUX_VERS) $(FLG32) -fno-pie -no-pie
 
 # __CVC_DEBUG__ must be turned on or the CVC debugging command line options
 # mostly +Odebug and +show_asm won't be recognized


### PR DESCRIPTION
I made these changes to overcome the "fPIC" problem on newer Debian/Ubuntu/Mint distros.  See my comment linked below for more details:

https://github.com/cambridgehackers/open-src-cvc/issues/1#issuecomment-451356895