### PR TITLE
Fix build for recent GCC

### DIFF
--- a/src/cvmacros.h
+++ b/src/cvmacros.h
@@ -387,6 +387,7 @@ extern void __record_sel_nchg(struct net_t *, int32, int32);
 /* but one record called, it must be off for dctrl processing - not needed */ 
 /* DBG ??? release add --- */
 /* AIV 11/29/10 - need to check for toggle coverage */
+extern void __add_dmpv_chglst_el_sel(struct net_t *, int32);
 #define record_sel_nchg_(np, i1, i2) \
  do { \
   __lhs_changed = FALSE; \

--- a/src/v_asmlnk.c
+++ b/src/v_asmlnk.c
@@ -168,6 +168,11 @@ OF SUCH DAMAGE.
  * compiler asm gen routines - routines for post lowering asm gen here
  */
 
+/* AIV 03/28/12 - this is needed for some systems for clone call */
+// #ifndef _GNU_SOURCE
+// #define _GNU_SOURCE
+// #endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -188,12 +193,6 @@ OF SUCH DAMAGE.
 #ifndef __RHEL4X__
 #include <linux/sched.h>
 #endif
-
-/* AIV 03/28/12 - this is needed for some systems for clone call */
-// #ifndef _GNU_SOURCE
-// ##define _GNU_SOURCE
-// #endif
-
 
 #ifdef __DBMALLOC__
 #include "../malloc.h"


### PR DESCRIPTION
Hey everyone, 

I got these two build errors while building CVC: 

```
cvmacros.h:400:5: error: implicit declaration of function ‘__add_dmpv_chglst_el_sel’;
did you mean ‘__add_dp_chglst_el’? [-Wimplicit-function-declaration] __add_dmpv_chglst_el_sel(np, i1);
```

```
v_asmlnk.c:10590:8: error: implicit declaration of function ‘clone’;
did you mean ‘close’? [-Wimplicit-function-declaration] pid = clone(popen_child_process_func, stack_aligned, ...
```

I'm on Arch Linux, Kernel 6.11.7 and have GCC version 14.2.1. 
